### PR TITLE
save device token without duplication

### DIFF
--- a/mobile/APIs/save_device_token.php
+++ b/mobile/APIs/save_device_token.php
@@ -5,5 +5,10 @@
 
 include_once '../BLL/device_token.php';
 
+//This variable stores the device token that got from the URL.
+$device_token_get = $_GET['deviceToken'];
 $device_token = new device_token();
-$device_token->store_device_token($_GET['deviceToken']);
+//Here I'll delete all the duplicate device tokens from the DB.
+$device_token->delete_duplicated_tokens($device_token_get);
+//Here I'll store the device token in the DB.
+$device_token->store_device_token($device_token_get);

--- a/mobile/BLL/device_token.php
+++ b/mobile/BLL/device_token.php
@@ -6,11 +6,22 @@ include_once '../DAL/my_db.php';
 
 //this class to make modifications on the user_token table.
 class device_token extends my_db {
-    
-     public function get_all_device_token() {
+
+    public function get_all_device_token() {
         return $this->get_all_data('SELECT device_token FROM `device_token`');
     }
 
+    //this function will delete all the tokens that are the same as the new one 
+    //that will be stored.
+    //Because if there is duplication in the DB the same message will be 
+    //sent multiple times for the same device.
+    function delete_duplicated_tokens($device_token) {
+        $this->mod_data('DELETE FROM `device_token` WHERE device_token.device_token = ?'
+                , 's', array(&$device_token));
+    }
+
+    //This function will store the mobile device token in the DB to be able to 
+    //receive FCM messages.
     function store_device_token($device_token) {
         /* here i'll store the device_token in the table, and i'll get the value 
           from the url */


### PR DESCRIPTION
In this branch, I've managed to store the mobile token without duplication in the DB because I don't want the same message to be sent multiple times for the same device.